### PR TITLE
Do not return entire response.inspect in error

### DIFF
--- a/lib/frontapp/error.rb
+++ b/lib/frontapp/error.rb
@@ -14,8 +14,10 @@ module Frontapp
 
     def initialize(response)
       @response = response
-      super("Response: #{response.inspect}\nBody: #{response.body}")
+      super("Response Body: #{response.body}")
     end
+
+    attr_reader :response
   end
 
   class BadRequestError < Error; end


### PR DESCRIPTION
Do not return entire response.inspect in error in case we log it or track it; mostly because the response.inspect includes the response headers, which includes auth tokens. 

Additionally, expose the response object attached to the Frontapp error so we can have control over logging anything else from the response, or extracting useful information from the response headers such as rate limiting values


## how to test
1. Go to our stepful app directory locally and checkout [this branch](https://github.com/stepful/stepful/compare/point-to-new-frontapp-branch?expand=1) which uses this version of frontapp
2. Run `bundle install`
3. Open the rails console and make a call to Front using the FrontClient that would cause an error to be thrown; for example:
```
FrontClient.get_contact('bad')
```

Confirm that the error message does NOT include the entire response.inspect, but just the Response body

### before
```
> FrontClient.get_contact('bad')
Response: #<Faraday::Response:0x000000013aad9810 @on_complete_callbacks=[], @env=#<Faraday::Env @method=:get @url=#<URI::HTTPS https://api2.frontapp.com/contacts/bad> @request=#<Faraday::RequestOptions (empty)> @request_headers={"Accept"=>"application/json", "Authorization"=>"Bearer {OMITTED}", "User-agent"=>"Frontapp Ruby Gem 0.0.12"} @ssl=#<Faraday::SSLOptions verify=true> @response=#<Faraday::Response:0x000000013aad9810 ...> @response_headers={"date"=>"Wed, 15 Jan 2025 18:59:13 GMT", "content-type"=>"application/json; charset=utf-8", "content-length"=>"80", "connection"=>"keep-alive", "x-ratelimit-limit"=>"200", "x-ratelimit-remaining"=>"157", "x-ratelimit-reset"=>"1736967554.698", "etag"=>"W/\"50-Javz0jz+ChpoJ7SEIYwcnK+nKLY\"", "x-front-time"=>"110"} @status=404 @reason_phrase="Not Found" @response_body="{\"_error\":{\"status\":404,\"title\":\"Not found\",\"message\":\"Unknown contact ID bad\"}}">> (Frontapp::NotFoundError)
Body: {"_error":{"status":404,"title":"Not found","message":"Unknown contact ID bad"}}
```

### after
```
> FrontClient.get_contact('bad')
Response Body: {"_error":{"status":404,"title":"Not found","message":"Unknown contact ID bad"}} (Frontapp::NotFoundError)
```